### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/alexmensch/eleventy-plugin-cloudflare-kv/security/code-scanning/1](https://github.com/alexmensch/eleventy-plugin-cloudflare-kv/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. Since none of the jobs in this workflow need to write to the repository or interact with issues or pull requests, the minimal permission required is `contents: read`. The best way to implement this is to add the `permissions` block at the top level of the workflow (before the `jobs:` key), so it applies to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
